### PR TITLE
Handle empty and tiny localization inputs without crashing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMFrameConnection"
 uuid = "1517b1a9-81e8-461f-b994-92eb29599690"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/src/combinelocalizations.jl
+++ b/src/combinelocalizations.jl
@@ -23,6 +23,9 @@ function combinelocalizations(smld::BasicSMLD{T,E};
     track_length::Union{Tuple{Float64,Float64},Nothing}=nothing) where {T, E<:SMLMData.AbstractEmitter}
     # Extract arrays from emitters
     emitters = smld.emitters
+    # Nothing to combine: return the (empty) input unchanged. The reductions
+    # below (`counts`, `first(emitters)`) assume at least one localization.
+    isempty(emitters) && return smld
     connectID = [e.track_id for e in emitters]
     sortindices = sortperm(connectID)
     connectID = connectID[sortindices]

--- a/src/frameconnect.jl
+++ b/src/frameconnect.jl
@@ -65,6 +65,32 @@ end
 function frameconnect(smld::BasicSMLD{T,E}, config::FrameConnectConfig) where {T, E<:SMLMData.AbstractEmitter}
     t_start = time()
 
+    # Degrade gracefully on empty input: there is nothing to connect, so return
+    # the (empty) input unchanged with a zeroed info. This short-circuits before
+    # the downstream pipeline (precluster, estimateparams, ...), which otherwise
+    # reduces over empty collections and throws (e.g. `counts` on an empty frame
+    # vector, or `zero(Type{Any})` for an untyped empty emitter vector).
+    if isempty(smld.emitters)
+        # Mirror the non-empty path's calibration contract: when calibration is
+        # configured, still emit a (graceful fallback) CalibrationResult rather
+        # than `nothing`, so downstream code that reads `info.calibration.*` sees
+        # the same shape for 0 and 1-2 localizations. analyze_calibration is
+        # empty-safe (0 pairs -> calibration_applied=false fallback).
+        cal_result = config.calibration === nothing ? nothing :
+                     analyze_calibration(smld, config.calibration)
+        info = FrameConnectInfo{T}(
+            smld,                 # connected: input passthrough (no tracks to assign)
+            0, 0, 0, 0,           # n_input, n_tracks, n_combined, n_filtered
+            0.0, 0.0, 0.0, 0.0,   # k_on, k_off, k_bleach, p_miss
+            Float64[],            # initial_density
+            time() - t_start,     # elapsed_s
+            :lap,                 # algorithm
+            0,                    # n_preclusters
+            cal_result,           # calibration: nothing if disabled, else fallback
+        )
+        return (smld, info)
+    end
+
     # Prepare a ParamStruct to keep track of parameters used.
     params = ParamStruct()
     params.n_density_neighbors = config.n_density_neighbors

--- a/src/precluster.jl
+++ b/src/precluster.jl
@@ -28,6 +28,11 @@ function precluster(smld::BasicSMLD{T,E},
     emitters = smld.emitters
     n_emitters = length(emitters)
 
+    # Nothing to cluster: return the (empty) input unchanged. The reductions
+    # below (`counts` on datasetnum/framenum, `first(emitters)`) assume at least
+    # one localization and otherwise throw on an empty collection.
+    n_emitters == 0 && return smld
+
     framenum = [e.frame for e in emitters]
     datasetnum = [e.dataset for e in emitters]
     x = [e.x for e in emitters]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ include("test_helpers.jl")
     include("test_types.jl")
     include("test_combinelocalizations.jl")
     include("test_frameconnect.jl")
+    include("test_empty_input.jl")
     include("test_defineidealFC.jl")
     include("test_calibration.jl")
 end

--- a/test/test_empty_input.jl
+++ b/test/test_empty_input.jl
@@ -1,0 +1,122 @@
+# Robustness tests for empty (0) and tiny (1-2) localization inputs.
+#
+# frameconnect and its building blocks previously crashed on near-empty data
+# (e.g. `MethodError: zero(Type{Any})` / `reducing over an empty collection`)
+# when reductions like `counts`/`mean`/`extrema` ran over empty collections.
+# These tests pin the graceful behavior: a passthrough/empty result, no crash.
+
+@testset "empty and tiny inputs" begin
+    cam = make_test_camera()
+    # Build SMLDs directly here: make_test_smld reduces over emitters (maximum
+    # frame) and so cannot construct a 0-emitter SMLD.
+    empty_smld(; nframes=0) =
+        BasicSMLD(Emitter2DFit{Float64}[], cam, nframes, 1, Dict{String,Any}())
+
+    @testset "frameconnect: empty SMLD (n_frames=0)" begin
+        smld = empty_smld()
+        (combined, info) = frameconnect(smld)
+
+        @test combined isa BasicSMLD
+        @test isempty(combined.emitters)
+        @test info isa FrameConnectInfo{Float64}
+        @test info.n_input == 0
+        @test info.n_tracks == 0
+        @test info.n_combined == 0
+        @test info.n_preclusters == 0
+        @test info.n_filtered == 0
+        @test info.calibration === nothing
+        @test info.elapsed_s >= 0
+    end
+
+    @testset "frameconnect: empty SMLD (n_frames>0)" begin
+        smld = empty_smld(nframes=100)
+        (combined, info) = frameconnect(smld)
+        @test isempty(combined.emitters)
+        @test info.n_combined == 0
+    end
+
+    @testset "frameconnect: empty SMLD preserves camera/datasets" begin
+        smld = empty_smld()
+        (combined, info) = frameconnect(smld)
+        @test combined.camera == smld.camera
+        @test info.connected.camera == smld.camera
+        @test combined.n_datasets == smld.n_datasets
+    end
+
+    @testset "frameconnect: empty SMLD with calibration falls back gracefully" begin
+        # Calibration enabled + empty input must mirror the tiny-input contract:
+        # a CalibrationResult with calibration_applied=false, NOT `nothing`, so
+        # downstream code reading info.calibration.* sees a uniform shape.
+        smld = empty_smld()
+        config = FrameConnectConfig(calibration=CalibrationConfig())
+        (combined, info) = frameconnect(smld, config)
+
+        @test isempty(combined.emitters)
+        @test info.calibration !== nothing
+        @test info.calibration.calibration_applied == false
+        @test info.calibration.n_pairs == 0
+    end
+
+    @testset "frameconnect: single localization" begin
+        smld = make_test_smld([make_emitter(5.0, 5.0, 1)]; n_frames=1)
+        (combined, info) = frameconnect(smld)
+        @test length(combined.emitters) == 1
+        @test info.n_input == 1
+        @test info.n_combined == 1
+    end
+
+    @testset "frameconnect: single localization with calibration" begin
+        smld = make_test_smld([make_emitter(5.0, 5.0, 1)]; n_frames=1)
+        config = FrameConnectConfig(calibration=CalibrationConfig())
+        (combined, info) = frameconnect(smld, config)
+        @test length(combined.emitters) == 1
+        @test info.calibration !== nothing
+        @test info.calibration.calibration_applied == false  # 0 frame-to-frame pairs
+    end
+
+    @testset "frameconnect: two localizations (one molecule)" begin
+        # Small jitter (via make_blinking_molecule) avoids a degenerate
+        # zero-area cluster from two identical positions.
+        emitters = make_blinking_molecule(5.0, 5.0, [1, 2])
+        smld = make_test_smld(emitters; n_frames=2)
+        (combined, info) = frameconnect(smld)
+        @test combined isa BasicSMLD
+        @test info.n_input == 2
+        @test length(combined.emitters) >= 1
+        @test length(combined.emitters) <= 2
+    end
+
+    @testset "frameconnect: two localizations (separated)" begin
+        emitters = [make_emitter(5.0, 5.0, 1), make_emitter(8.0, 8.0, 1)]
+        smld = make_test_smld(emitters; n_frames=1)
+        (combined, info) = frameconnect(smld)
+        @test info.n_input == 2
+        @test length(combined.emitters) >= 1
+    end
+
+    @testset "frameconnect: empty SMLD (abstract emitter eltype)" begin
+        # An untyped/abstract emitter vector makes the internal reductions
+        # produce Any[] collections, which is what triggered the original
+        # `MethodError: zero(Type{Any})`. The empty guard must handle this
+        # regardless of element type.
+        smld = BasicSMLD(Emitter2DFit[], cam, 0, 1, Dict{String,Any}())
+        (combined, info) = frameconnect(smld)
+        @test isempty(combined.emitters)
+        @test info.n_input == 0
+        @test info.n_combined == 0
+    end
+
+    @testset "combinelocalizations: empty passthrough" begin
+        smld = empty_smld()
+        out = combinelocalizations(smld)
+        @test out isa BasicSMLD
+        @test isempty(out.emitters)
+    end
+
+    @testset "precluster: empty passthrough" begin
+        smld = empty_smld()
+        out = SMLMFrameConnection.precluster(smld)
+        @test out isa BasicSMLD
+        @test isempty(out.emitters)
+    end
+end


### PR DESCRIPTION
## Summary

`frameconnect` and its building blocks crashed on a `BasicSMLD` with **0 (or untyped/abstract) emitters**: internal reductions (`counts`/`mean`/`extrema`) ran over empty collections, producing `MethodError: zero(Type{Any})` from `reduce_empty(+, Type{Any})` and `"reducing over an empty collection"`. This surfaced from the SMLMAnalysis pipeline on near-empty dSTORM cells (some cells yield ~0 localizations) — the pipeline should degrade gracefully, not crash.

## Changes

`isempty` guards at the empty-input sites so 0-localization data returns a passthrough/empty result instead of crashing:

- **`frameconnect`** — early-return the (empty) input + a zeroed `FrameConnectInfo` before the pipeline. When calibration is configured, it still emits a graceful fallback `CalibrationResult` (`calibration_applied=false`) so downstream code reading `info.calibration.*` sees a uniform shape for 0 vs 1–2 localizations.
- **`precluster`** — return the input unchanged for 0 emitters (guards `counts` on datasetnum/framenum and `first(emitters)`).
- **`combinelocalizations`** — return the input unchanged for 0 emitters.
- **`calibration.jl`** — no change needed; `analyze_calibration` already falls back at `n_pairs < 100` before any reduction, and the empty branch reuses it.

## Tests

New `test/test_empty_input.jl` covers 0/1/2 localizations × (default + calibration-enabled) × (concrete + abstract `Emitter2DFit` eltype), plus the `combinelocalizations`/`precluster` building blocks.

Full suite: **224/224 pass**. 0-emitter `BasicSMLD` now returns `(empty_smld, info)` with `n_combined=0`; 1/2/9-loc inputs return cleanly; calibration-enabled empty/tiny → `calibration_applied=false`.

## Notes

- Patch bump **0.3.2 → 0.3.3**. Draft / branch-only — **not for merge or registration** in this state.
- Out of scope (separate, pre-existing): two localizations at *exactly identical* float positions → zero-area cluster → `Inf` density → Optim/LAP spins. Does not occur with real sub-pixel data; can be a follow-up if a real cell ever triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)